### PR TITLE
feat(regclient,deregister): add client for interacting with registries, deregister method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
           name: install test deps
           command: go get github.com/jstemmer/go-junit-report github.com/golang/lint/golint
       - run: 
-          name: install deps
-          command: make install
-      - run: 
           name: Run Lint Tests
           command: golint -set_exit_status ./...
+      - run: 
+          name: install deps
+          command: make install-deps
       - run:
           name: Run Tests
           command: |

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,6 @@ ifndef GOPATH
   $(error $GOPATH must be set. plz check: https://github.com/golang/go/wiki/SettingGOPATH)
 endif
 
-install: require-gopath
+install-deps: require-gopath
 	go get -v github.com/libp2p/go-libp2p-crypto github.com/jbenet/go-multihash github.com/sirupsen/logrus github.com/datatogether/api/apiutil
+	

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -56,6 +56,16 @@ func TestProfilesRegister(t *testing.T) {
 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
 		}
 	}
+
+	if err := ps.Deregister(&Profile{}); err == nil {
+		t.Error("invalid profile should error")
+	}
+	if err := ps.Deregister(&Profile{ProfileID: p.ProfileID, Handle: p.Handle, PublicKey: p.PublicKey, Signature: base64.StdEncoding.EncodeToString(mismatchSig)}); err == nil {
+		t.Error("unverifiable profile should error")
+	}
+	if err := ps.Deregister(p2); err != nil {
+		t.Errorf("error deregistering: %s", err.Error())
+	}
 }
 
 func TestProfilesSortedRange(t *testing.T) {

--- a/regclient/client.go
+++ b/regclient/client.go
@@ -1,0 +1,105 @@
+// Package regclient defines a client for interacting with a registry server
+package regclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/libp2p/go-libp2p-crypto"
+	"github.com/qri-io/registry"
+)
+
+// ErrNoRegistry indicates that no registry has been specified
+// all client methods MUST return ErrNoRegistry for all method calls
+// when config.Registry.Location is an empty string
+var ErrNoRegistry = fmt.Errorf("registry: no registry specified")
+
+// Client wraps a registry configuration with methods for interacting
+// with the configured registry
+type Client struct {
+	cfg *Config
+}
+
+// Config encapsulates options for working with a registry
+type Config struct {
+	// Location is the URL base to call to
+	Location string
+}
+
+// NewClient creates a registry from a provided Registry configuration
+func NewClient(cfg *Config) *Client {
+	return &Client{cfg}
+}
+
+// GetProfile fills in missing fields in p with registry data
+func (r Client) GetProfile(p *registry.Profile) error {
+	pro, err := r.doJSONProfileReq("GET", p)
+	if err != nil {
+		return err
+	}
+	*p = *pro
+	return nil
+}
+
+// PutProfile adds a profile to the registry
+func (r Client) PutProfile(handle string, privKey crypto.PrivKey) error {
+	p, err := registry.ProfileFromPrivateKey(handle, privKey)
+	if err != nil {
+		return err
+	}
+	_, err = r.doJSONProfileReq("POST", p)
+	return err
+}
+
+// DeleteProfile removes a profile from the registry
+func (r Client) DeleteProfile(handle string, privKey crypto.PrivKey) error {
+	p, err := registry.ProfileFromPrivateKey(handle, privKey)
+	if err != nil {
+		return err
+	}
+	_, err = r.doJSONProfileReq("DELETE", p)
+	return nil
+}
+
+// doJSONProfileReq is a common wrapper for /profile endpoint requests
+func (r Client) doJSONProfileReq(method string, p *registry.Profile) (*registry.Profile, error) {
+	if r.cfg.Location == "" {
+		return nil, ErrNoRegistry
+	}
+
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/profile", r.cfg.Location), bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	env := struct {
+		Data *registry.Profile
+		Meta struct {
+			Error  string
+			Status string
+			Code   int
+		}
+	}{}
+
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error %d: %s", res.StatusCode, env.Meta.Error)
+	}
+
+	return env.Data, nil
+}

--- a/regclient/client_test.go
+++ b/regclient/client_test.go
@@ -1,0 +1,75 @@
+package regclient
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-crypto"
+	"github.com/qri-io/registry"
+	"github.com/qri-io/registry/regserver/handlers"
+)
+
+// base64-encoded Test Private Key, decoded in init
+// peerId: QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt
+var (
+	pk1Bytes = []byte(`CAASpgkwggSiAgEAAoIBAQC/7Q7fILQ8hc9g07a4HAiDKE4FahzL2eO8OlB1K99Ad4L1zc2dCg+gDVuGwdbOC29IngMA7O3UXijycckOSChgFyW3PafXoBF8Zg9MRBDIBo0lXRhW4TrVytm4Etzp4pQMyTeRYyWR8e2hGXeHArXM1R/A/SjzZUbjJYHhgvEE4OZy7WpcYcW6K3qqBGOU5GDMPuCcJWac2NgXzw6JeNsZuTimfVCJHupqG/dLPMnBOypR22dO7yJIaQ3d0PFLxiDG84X9YupF914RzJlopfdcuipI+6gFAgBw3vi6gbECEzcohjKf/4nqBOEvCDD6SXfl5F/MxoHurbGBYB2CJp+FAgMBAAECggEAaVOxe6Y5A5XzrxHBDtzjlwcBels3nm/fWScvjH4dMQXlavwcwPgKhy2NczDhr4X69oEw6Msd4hQiqJrlWd8juUg6vIsrl1wS/JAOCS65fuyJfV3Pw64rWbTPMwO3FOvxj+rFghZFQgjg/i45uHA2UUkM+h504M5Nzs6Arr/rgV7uPGR5e5OBw3lfiS9ZaA7QZiOq7sMy1L0qD49YO1ojqWu3b7UaMaBQx1Dty7b5IVOSYG+Y3U/dLjhTj4Hg1VtCHWRm3nMOE9cVpMJRhRzKhkq6gnZmni8obz2BBDF02X34oQLcHC/Wn8F3E8RiBjZDI66g+iZeCCUXvYz0vxWAQQKBgQDEJu6flyHPvyBPAC4EOxZAw0zh6SF/r8VgjbKO3n/8d+kZJeVmYnbsLodIEEyXQnr35o2CLqhCvR2kstsRSfRz79nMIt6aPWuwYkXNHQGE8rnCxxyJmxV4S63GczLk7SIn4KmqPlCI08AU0TXJS3zwh7O6e6kBljjPt1mnMgvr3QKBgQD6fAkdI0FRZSXwzygx4uSg47Co6X6ESZ9FDf6ph63lvSK5/eue/ugX6p/olMYq5CHXbLpgM4EJYdRfrH6pwqtBwUJhlh1xI6C48nonnw+oh8YPlFCDLxNG4tq6JVo071qH6CFXCIank3ThZeW5a3ZSe5pBZ8h4bUZ9H8pJL4C7yQKBgFb8SN/+/qCJSoOeOcnohhLMSSD56MAeK7KIxAF1jF5isr1TP+rqiYBtldKQX9bIRY3/8QslM7r88NNj+aAuIrjzSausXvkZedMrkXbHgS/7EAPflrkzTA8fyH10AsLgoj/68mKr5bz34nuY13hgAJUOKNbvFeC9RI5g6eIqYH0FAoGAVqFTXZp12rrK1nAvDKHWRLa6wJCQyxvTU8S1UNi2EgDJ492oAgNTLgJdb8kUiH0CH0lhZCgr9py5IKW94OSM6l72oF2UrS6PRafHC7D9b2IV5Al9lwFO/3MyBrMocapeeyaTcVBnkclz4Qim3OwHrhtFjF1ifhP9DwVRpuIg+dECgYANwlHxLe//tr6BM31PUUrOxP5Y/cj+ydxqM/z6papZFkK6Mvi/vMQQNQkh95GH9zqyC5Z/yLxur4ry1eNYty/9FnuZRAkEmlUSZ/DobhU0Pmj8Hep6JsTuMutref6vCk2n02jc9qYmJuD7iXkdXDSawbEG6f5C4MUkJ38z1t1OjA==`)
+	pk1      crypto.PrivKey
+)
+
+func init() {
+	data, err := base64.StdEncoding.DecodeString(string(pk1Bytes))
+	if err != nil {
+		panic(err)
+	}
+	pk1Bytes = data
+
+	pk1, err = crypto.UnmarshalPrivateKey(pk1Bytes)
+	if err != nil {
+		panic(fmt.Errorf("error unmarshaling private key: %s", err.Error()))
+		return
+	}
+}
+
+func TestProfileRequests(t *testing.T) {
+	handle := "b5"
+	ts := httptest.NewServer(handlers.NewRoutes(registry.NewProfiles()))
+	c := NewClient(&Config{
+		Location: ts.URL,
+	})
+
+	pubBytes, err := pk1.GetPublic().Bytes()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	p := &registry.Profile{
+		PublicKey: base64.StdEncoding.EncodeToString(pubBytes),
+	}
+
+	err = c.GetProfile(p)
+	if err == nil {
+		t.Errorf("expected empty get to error")
+	} else if err.Error() != "error 404: " {
+		t.Errorf("error mistmatch. expected: %s, got: %s", "error 404: ", err.Error())
+	}
+
+	err = c.PutProfile(handle, pk1)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	err = c.GetProfile(p)
+	if err != nil {
+		t.Error(err)
+	}
+	if p.Handle != handle {
+		t.Errorf("expected handle to equal %s, got: %s", handle, p.Handle)
+	}
+
+	err = c.DeleteProfile(handle, pk1)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}

--- a/regserver/dockerfile
+++ b/regserver/dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.9
+LABEL maintainer="sparkle_pony_2000@qri.io"
+
+ADD . /go/src/github.com/qri-io/peerns
+RUN cd /go/src/github.com/qri-io/peerns
+RUN go get -v github.com/datatogether/api/apiutil github.com/sirupsen/logrus
+RUN go install github.com/qri-io/peerns
+
+# set default port
+ENV PORT=3001
+EXPOSE 3001
+
+# Set binary as entrypoint, initalizing ipfs repo if none is mounted
+CMD ["peerns"]

--- a/regserver/handlers/profile.go
+++ b/regserver/handlers/profile.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/registry"
+)
+
+// NewProfilesHandler creates a profiles handler function that operates
+// on a *registry.Profiles
+func NewProfilesHandler(profiles *registry.Profiles) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ps := make([]*registry.Profile, profiles.Len())
+
+		i := 0
+		profiles.SortedRange(func(key string, p *registry.Profile) bool {
+			ps[i] = p
+			i++
+			return false
+		})
+
+		apiutil.WriteResponse(w, ps)
+	}
+}
+
+// NewProfileHandler creates a profile handler func that operats on
+// a *registry.Profiles
+func NewProfileHandler(profiles *registry.Profiles) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := &registry.Profile{}
+		switch r.Header.Get("Content-Type") {
+		case "application/json":
+			if err := json.NewDecoder(r.Body).Decode(p); err != nil {
+				apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
+				return
+			}
+		default:
+			err := fmt.Errorf("Content-Type must be application/json")
+			apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
+			return
+		}
+
+		switch r.Method {
+		case "GET":
+			var ok bool
+			if p.Handle != "" {
+				p, ok = profiles.Load(p.Handle)
+			} else {
+				profiles.Range(func(handle string, profile *registry.Profile) bool {
+					if profile.ProfileID == p.ProfileID || profile.PublicKey == p.PublicKey {
+						p = profile
+						ok = true
+						return true
+					}
+					return false
+				})
+			}
+			if !ok {
+				apiutil.NotFoundHandler(w, r)
+				return
+			}
+		case "PUT", "POST":
+			if err := profiles.Register(p); err != nil {
+				apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
+				return
+			}
+		case "DELETE":
+			if err := profiles.Deregister(p); err != nil {
+				apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
+				return
+			}
+		default:
+			apiutil.NotFoundHandler(w, r)
+			return
+		}
+
+		apiutil.WriteResponse(w, p)
+	}
+}

--- a/regserver/handlers/profile_test.go
+++ b/regserver/handlers/profile_test.go
@@ -1,0 +1,239 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-crypto"
+	"github.com/qri-io/registry"
+)
+
+// base64-encoded Test Private Key, decoded in init
+// peerId: QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt
+var (
+	testPk1  = []byte(`CAASpgkwggSiAgEAAoIBAQC/7Q7fILQ8hc9g07a4HAiDKE4FahzL2eO8OlB1K99Ad4L1zc2dCg+gDVuGwdbOC29IngMA7O3UXijycckOSChgFyW3PafXoBF8Zg9MRBDIBo0lXRhW4TrVytm4Etzp4pQMyTeRYyWR8e2hGXeHArXM1R/A/SjzZUbjJYHhgvEE4OZy7WpcYcW6K3qqBGOU5GDMPuCcJWac2NgXzw6JeNsZuTimfVCJHupqG/dLPMnBOypR22dO7yJIaQ3d0PFLxiDG84X9YupF914RzJlopfdcuipI+6gFAgBw3vi6gbECEzcohjKf/4nqBOEvCDD6SXfl5F/MxoHurbGBYB2CJp+FAgMBAAECggEAaVOxe6Y5A5XzrxHBDtzjlwcBels3nm/fWScvjH4dMQXlavwcwPgKhy2NczDhr4X69oEw6Msd4hQiqJrlWd8juUg6vIsrl1wS/JAOCS65fuyJfV3Pw64rWbTPMwO3FOvxj+rFghZFQgjg/i45uHA2UUkM+h504M5Nzs6Arr/rgV7uPGR5e5OBw3lfiS9ZaA7QZiOq7sMy1L0qD49YO1ojqWu3b7UaMaBQx1Dty7b5IVOSYG+Y3U/dLjhTj4Hg1VtCHWRm3nMOE9cVpMJRhRzKhkq6gnZmni8obz2BBDF02X34oQLcHC/Wn8F3E8RiBjZDI66g+iZeCCUXvYz0vxWAQQKBgQDEJu6flyHPvyBPAC4EOxZAw0zh6SF/r8VgjbKO3n/8d+kZJeVmYnbsLodIEEyXQnr35o2CLqhCvR2kstsRSfRz79nMIt6aPWuwYkXNHQGE8rnCxxyJmxV4S63GczLk7SIn4KmqPlCI08AU0TXJS3zwh7O6e6kBljjPt1mnMgvr3QKBgQD6fAkdI0FRZSXwzygx4uSg47Co6X6ESZ9FDf6ph63lvSK5/eue/ugX6p/olMYq5CHXbLpgM4EJYdRfrH6pwqtBwUJhlh1xI6C48nonnw+oh8YPlFCDLxNG4tq6JVo071qH6CFXCIank3ThZeW5a3ZSe5pBZ8h4bUZ9H8pJL4C7yQKBgFb8SN/+/qCJSoOeOcnohhLMSSD56MAeK7KIxAF1jF5isr1TP+rqiYBtldKQX9bIRY3/8QslM7r88NNj+aAuIrjzSausXvkZedMrkXbHgS/7EAPflrkzTA8fyH10AsLgoj/68mKr5bz34nuY13hgAJUOKNbvFeC9RI5g6eIqYH0FAoGAVqFTXZp12rrK1nAvDKHWRLa6wJCQyxvTU8S1UNi2EgDJ492oAgNTLgJdb8kUiH0CH0lhZCgr9py5IKW94OSM6l72oF2UrS6PRafHC7D9b2IV5Al9lwFO/3MyBrMocapeeyaTcVBnkclz4Qim3OwHrhtFjF1ifhP9DwVRpuIg+dECgYANwlHxLe//tr6BM31PUUrOxP5Y/cj+ydxqM/z6papZFkK6Mvi/vMQQNQkh95GH9zqyC5Z/yLxur4ry1eNYty/9FnuZRAkEmlUSZ/DobhU0Pmj8Hep6JsTuMutref6vCk2n02jc9qYmJuD7iXkdXDSawbEG6f5C4MUkJ38z1t1OjA==`)
+	privKey1 crypto.PrivKey
+)
+
+func init() {
+	data, err := base64.StdEncoding.DecodeString(string(testPk1))
+	if err != nil {
+		panic(err)
+	}
+	testPk1 = data
+
+	privKey1, err = crypto.UnmarshalPrivateKey(testPk1)
+	if err != nil {
+		panic(fmt.Errorf("error unmarshaling private key: %s", err.Error()))
+		return
+	}
+}
+
+func TestProfile(t *testing.T) {
+	s := httptest.NewServer(NewRoutes(registry.NewProfiles()))
+
+	p1, err := registry.ProfileFromPrivateKey("b5", privKey1)
+	if err != nil {
+		t.Errorf("error generating profile: %s", err.Error())
+		return
+	}
+
+	p1Rename, err := registry.ProfileFromPrivateKey("b6", privKey1)
+	if err != nil {
+		t.Errorf("error generating profile: %s", err.Error())
+		return
+	}
+
+	type env struct {
+		Data *registry.Profile
+		Meta struct {
+			Code int
+		}
+	}
+
+	b5 := &registry.Profile{
+		ProfileID: "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
+		Handle:    "b5",
+		PublicKey: "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/7Q7fILQ8hc9g07a4HAiDKE4FahzL2eO8OlB1K99Ad4L1zc2dCg+gDVuGwdbOC29IngMA7O3UXijycckOSChgFyW3PafXoBF8Zg9MRBDIBo0lXRhW4TrVytm4Etzp4pQMyTeRYyWR8e2hGXeHArXM1R/A/SjzZUbjJYHhgvEE4OZy7WpcYcW6K3qqBGOU5GDMPuCcJWac2NgXzw6JeNsZuTimfVCJHupqG/dLPMnBOypR22dO7yJIaQ3d0PFLxiDG84X9YupF914RzJlopfdcuipI+6gFAgBw3vi6gbECEzcohjKf/4nqBOEvCDD6SXfl5F/MxoHurbGBYB2CJp+FAgMBAAE=",
+	}
+
+	b6 := &registry.Profile{
+		ProfileID: "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
+		Handle:    "b6",
+		PublicKey: "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/7Q7fILQ8hc9g07a4HAiDKE4FahzL2eO8OlB1K99Ad4L1zc2dCg+gDVuGwdbOC29IngMA7O3UXijycckOSChgFyW3PafXoBF8Zg9MRBDIBo0lXRhW4TrVytm4Etzp4pQMyTeRYyWR8e2hGXeHArXM1R/A/SjzZUbjJYHhgvEE4OZy7WpcYcW6K3qqBGOU5GDMPuCcJWac2NgXzw6JeNsZuTimfVCJHupqG/dLPMnBOypR22dO7yJIaQ3d0PFLxiDG84X9YupF914RzJlopfdcuipI+6gFAgBw3vi6gbECEzcohjKf/4nqBOEvCDD6SXfl5F/MxoHurbGBYB2CJp+FAgMBAAE=",
+	}
+
+	cases := []struct {
+		method      string
+		endpoint    string
+		contentType string
+		profile     *registry.Profile
+		resStatus   int
+		res         *env
+	}{
+		{"OPTIONS", "/profile", "", nil, http.StatusBadRequest, nil},
+		{"OPTIONS", "/profile", "application/json", nil, http.StatusBadRequest, nil},
+		{"OPTIONS", "/profile", "application/json", &registry.Profile{Handle: "foo"}, http.StatusNotFound, nil},
+		{"POST", "/profile", "", nil, http.StatusBadRequest, nil},
+		{"POST", "/profile", "application/json", nil, http.StatusBadRequest, nil},
+		{"POST", "/profile", "application/json", &registry.Profile{Handle: p1.Handle}, http.StatusBadRequest, nil},
+		{"POST", "/profile", "application/json", &registry.Profile{Handle: p1.Handle, ProfileID: p1.ProfileID}, http.StatusBadRequest, nil},
+		{"POST", "/profile", "application/json", &registry.Profile{Handle: p1.Handle, ProfileID: p1.ProfileID, Signature: p1.Signature}, http.StatusBadRequest, nil},
+		{"POST", "/profile", "application/json", p1, http.StatusOK, nil},
+		{"GET", "/profile", "application/json", &registry.Profile{Handle: b5.Handle}, http.StatusOK, &env{Data: b5}},
+		{"GET", "/profile", "application/json", &registry.Profile{Handle: "b5"}, http.StatusOK, nil},
+		{"GET", "/profile", "application/json", &registry.Profile{Handle: "b6"}, http.StatusNotFound, nil},
+		{"GET", "/profile", "application/json", &registry.Profile{ProfileID: b5.ProfileID}, http.StatusOK, nil},
+		{"GET", "/profile", "application/json", &registry.Profile{ProfileID: "fooooo"}, http.StatusNotFound, nil},
+		{"POST", "/profile", "application/json", p1, http.StatusBadRequest, nil},
+		{"POST", "/profile", "application/json", p1Rename, http.StatusOK, nil},
+		{"GET", "/profile", "application/json", &registry.Profile{Handle: b6.Handle}, http.StatusOK, &env{Data: b6}},
+		{"DELETE", "/profile", "", p1Rename, http.StatusBadRequest, nil},
+		{"DELETE", "/profile", "application/json", nil, http.StatusBadRequest, nil},
+		{"DELETE", "/profile", "application/json", &registry.Profile{Handle: p1.Handle, ProfileID: p1.ProfileID, Signature: p1.Signature}, http.StatusBadRequest, nil},
+		{"DELETE", "/profile", "application/json", p1Rename, http.StatusOK, nil},
+	}
+
+	for i, c := range cases {
+		req, err := http.NewRequest(c.method, fmt.Sprintf("%s%s", s.URL, c.endpoint), nil)
+		if err != nil {
+			t.Errorf("case %d error creating request: %s", i, err.Error())
+			continue
+		}
+
+		if c.contentType != "" {
+			req.Header.Set("Content-Type", c.contentType)
+		}
+		if c.profile != nil {
+			data, err := json.Marshal(c.profile)
+			if err != nil {
+				t.Errorf("error marshaling json body: %s", err.Error())
+				return
+			}
+			req.Body = ioutil.NopCloser(bytes.NewReader([]byte(data)))
+		}
+
+		res, err := http.DefaultClient.Do(req)
+		if res.StatusCode != c.resStatus {
+			t.Errorf("case %d res status mismatch. expected: %d, got: %d", i, c.resStatus, res.StatusCode)
+			continue
+		}
+
+		if c.res != nil {
+			e := &env{}
+			if err := json.NewDecoder(res.Body).Decode(e); err != nil {
+				t.Errorf("case %d error reading response body: %s", i, err.Error())
+				continue
+			}
+
+			// if len(e.Data) != len(c.res.Data) {
+			// 	t.Errorf("case %d reponse body mismatch. expected %d, got: %d", i, len(e.Data), len(c.res.Data))
+			// 	continue
+			// }
+			if e.Data.Handle != c.res.Data.Handle {
+				t.Errorf("case %d reponse handle mismatch. expected %s, got: %s", i, e.Data.Handle, c.res.Data.Handle)
+			}
+
+			// TODO - check each response for profile matches
+		}
+	}
+}
+
+func TestProfiles(t *testing.T) {
+	s := httptest.NewServer(NewRoutes(registry.NewProfiles()))
+
+	p1, err := registry.ProfileFromPrivateKey("b5", privKey1)
+	if err != nil {
+		t.Errorf("error generating profile: %s", err.Error())
+		return
+	}
+
+	p1Rename, err := registry.ProfileFromPrivateKey("b6", privKey1)
+	if err != nil {
+		t.Errorf("error generating profile: %s", err.Error())
+		return
+	}
+
+	type env struct {
+		Data []*registry.Profile
+		Meta struct {
+			Code int
+		}
+	}
+
+	b5 := &registry.Profile{
+		ProfileID: "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
+		Handle:    "b5",
+		PublicKey: "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/7Q7fILQ8hc9g07a4HAiDKE4FahzL2eO8OlB1K99Ad4L1zc2dCg+gDVuGwdbOC29IngMA7O3UXijycckOSChgFyW3PafXoBF8Zg9MRBDIBo0lXRhW4TrVytm4Etzp4pQMyTeRYyWR8e2hGXeHArXM1R/A/SjzZUbjJYHhgvEE4OZy7WpcYcW6K3qqBGOU5GDMPuCcJWac2NgXzw6JeNsZuTimfVCJHupqG/dLPMnBOypR22dO7yJIaQ3d0PFLxiDG84X9YupF914RzJlopfdcuipI+6gFAgBw3vi6gbECEzcohjKf/4nqBOEvCDD6SXfl5F/MxoHurbGBYB2CJp+FAgMBAAE=",
+	}
+
+	b6 := &registry.Profile{
+		ProfileID: "QmZePf5LeXow3RW5U1AgEiNbW46YnRGhZ7HPvm1UmPFPwt",
+		Handle:    "b6",
+		PublicKey: "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/7Q7fILQ8hc9g07a4HAiDKE4FahzL2eO8OlB1K99Ad4L1zc2dCg+gDVuGwdbOC29IngMA7O3UXijycckOSChgFyW3PafXoBF8Zg9MRBDIBo0lXRhW4TrVytm4Etzp4pQMyTeRYyWR8e2hGXeHArXM1R/A/SjzZUbjJYHhgvEE4OZy7WpcYcW6K3qqBGOU5GDMPuCcJWac2NgXzw6JeNsZuTimfVCJHupqG/dLPMnBOypR22dO7yJIaQ3d0PFLxiDG84X9YupF914RzJlopfdcuipI+6gFAgBw3vi6gbECEzcohjKf/4nqBOEvCDD6SXfl5F/MxoHurbGBYB2CJp+FAgMBAAE=",
+	}
+
+	cases := []struct {
+		method      string
+		endpoint    string
+		contentType string
+		profile     *registry.Profile
+		resStatus   int
+		res         *env
+	}{
+		{"GET", "/profiles", "", nil, http.StatusOK, &env{}},
+		{"POST", "/profile", "application/json", p1, http.StatusOK, nil},
+		{"GET", "/profiles", "", nil, http.StatusOK, &env{Data: []*registry.Profile{b5}}},
+		{"POST", "/profile", "application/json", p1Rename, http.StatusOK, nil},
+		{"GET", "/profiles", "", nil, http.StatusOK, &env{Data: []*registry.Profile{b6}}},
+		{"DELETE", "/profile", "application/json", p1Rename, http.StatusOK, nil},
+		{"GET", "/profiles", "", nil, http.StatusOK, &env{Data: []*registry.Profile{}}},
+	}
+
+	for i, c := range cases {
+		req, err := http.NewRequest(c.method, fmt.Sprintf("%s%s", s.URL, c.endpoint), nil)
+		if err != nil {
+			t.Errorf("case %d error creating request: %s", i, err.Error())
+			continue
+		}
+
+		if c.contentType != "" {
+			req.Header.Set("Content-Type", c.contentType)
+		}
+		if c.profile != nil {
+			data, err := json.Marshal(c.profile)
+			if err != nil {
+				t.Errorf("error marshaling json body: %s", err.Error())
+				return
+			}
+			req.Body = ioutil.NopCloser(bytes.NewReader([]byte(data)))
+		}
+
+		res, err := http.DefaultClient.Do(req)
+		if res.StatusCode != c.resStatus {
+			t.Errorf("case %d res status mismatch. expected: %d, got: %d", i, c.resStatus, res.StatusCode)
+			continue
+		}
+
+		if c.res != nil {
+			e := &env{}
+			if err := json.NewDecoder(res.Body).Decode(e); err != nil {
+				t.Errorf("case %d error reading response body: %s", i, err.Error())
+				continue
+			}
+
+			if len(e.Data) != len(c.res.Data) {
+				t.Errorf("case %d reponse body mismatch. expected %d, got: %d", i, len(e.Data), len(c.res.Data))
+				continue
+			}
+
+			// TODO - check each response for profile matches
+		}
+	}
+}

--- a/regserver/handlers/routes.go
+++ b/regserver/handlers/routes.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/registry"
+	"github.com/sirupsen/logrus"
+)
+
+// logger
+var log = logrus.New()
+
+// NewRoutes allocates server handlers along standard routes
+func NewRoutes(ps *registry.Profiles) http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/", apiutil.HealthCheckHandler)
+	m.HandleFunc("/profile", logReq(NewProfileHandler(ps)))
+	m.HandleFunc("/profiles", logReq(NewProfilesHandler(ps)))
+
+	return m
+}
+
+func logReq(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Infof("%s %s %s", time.Now().Format(time.RFC3339), r.Method, r.URL.Path)
+		h.ServeHTTP(w, r)
+	}
+}

--- a/regserver/server.go
+++ b/regserver/server.go
@@ -1,0 +1,35 @@
+// Package regserver is a wrapper around the handlers package,
+// turning it into a proper http server
+package main
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/qri-io/registry"
+	"github.com/qri-io/registry/regserver/handlers"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// profiles
+	profiles = registry.NewProfiles()
+	// logger
+	log = logrus.New()
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+
+	s := http.Server{
+		Addr:    ":" + port,
+		Handler: handlers.NewRoutes(profiles),
+	}
+	log.Infof("serving on: %s\n", s.Addr)
+	if err := s.ListenAndServe(); err != nil {
+		log.Info(err.Error())
+	}
+}


### PR DESCRIPTION
This PR rounds out the first pass of tools for working with registries, adding a `regclient` package for calling methods and a `regserver` package for spinning up registry servers