### PR TITLE
Add in MockSearch and update request handling

### DIFF
--- a/regclient/dataset_test.go
+++ b/regclient/dataset_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/qri-io/registry/regserver/handlers"
 )
 
-var nilSearch registry.NilSearch
-
 func TestDatasetRequests(t *testing.T) {
 	handle := "b5"
 	name := "dataset"
-	srv := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), registry.NewMemDatasets(), nilSearch))
+	memDs := registry.NewMemDatasets()
+	srv := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), memDs, &registry.MockSearch{memDs}))
 	c := NewClient(&Config{
 		Location: srv.URL,
 	})

--- a/regclient/profile_test.go
+++ b/regclient/profile_test.go
@@ -34,7 +34,8 @@ func init() {
 
 func TestProfileRequests(t *testing.T) {
 	handle := "b5"
-	ts := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), registry.NewMemDatasets(), nilSearch))
+	memDs := registry.NewMemDatasets()
+	ts := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), memDs, &registry.MockSearch{memDs}))
 	c := NewClient(&Config{
 		Location: ts.URL,
 	})

--- a/regclient/search_test.go
+++ b/regclient/search_test.go
@@ -11,17 +11,14 @@ import (
 func TestSearchRequests(t *testing.T) {
 
 	searchParams := &SearchParams{QueryString: "presidents", Limit: 100, Offset: 0}
-
-	srv := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), registry.NewMemDatasets(), nilSearch))
+	memDs := registry.NewMemDatasets()
+	srv := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), memDs, &registry.MockSearch{memDs}))
 	c := NewClient(&Config{
 		Location: srv.URL,
 	})
-
-	expectedErr := "error 400: search not supported"
+	// TODO: need to add tests that actually inspect the search results
 	_, err := c.Search(searchParams)
-	if err == nil {
-		t.Errorf("expected nilSearch to return an error")
-	} else if err.Error() != expectedErr {
-		t.Errorf("error mismatch. expected: %s, got: %s", expectedErr, err.Error())
+	if err != nil {
+		t.Errorf("error executing search: %s", err)
 	}
 }

--- a/regserver/handlers/profile_test.go
+++ b/regserver/handlers/profile_test.go
@@ -53,7 +53,8 @@ func init() {
 }
 
 func TestProfile(t *testing.T) {
-	s := httptest.NewServer(NewRoutes(NewNoopProtector(), registry.NewMemProfiles(), registry.NewMemDatasets(), nilSearch))
+	ds := registry.NewMemDatasets()
+	s := httptest.NewServer(NewRoutes(NewNoopProtector(), registry.NewMemProfiles(), ds, registry.MockSearch{ds}))
 
 	p1, err := registry.ProfileFromPrivateKey("b5", privKey1)
 	if err != nil {

--- a/regserver/handlers/search_test.go
+++ b/regserver/handlers/search_test.go
@@ -1,52 +1,56 @@
 package handlers
 
 import (
-  "bytes"
-  "testing"
-  "fmt"
-  "io/ioutil"
-  "net/http"
-  "net/http/httptest"
-  "encoding/json"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-  "github.com/qri-io/registry"
+	"github.com/qri-io/registry"
 )
 
 func TestSearch(t *testing.T) {
-  s := httptest.NewServer(NewRoutes(NewNoopProtector(), registry.NewMemProfiles(), registry.NewMemDatasets(), nilSearch))
+	ds := registry.NewMemDatasets()
+	s := httptest.NewServer(NewRoutes(NewNoopProtector(), registry.NewMemProfiles(), ds, &registry.MockSearch{ds}))
 
-  cases := []struct {
-    method string
-    endpoint string
-    contentType string
-    params *registry.SearchParams
-    resStatus int
+	cases := []struct {
+		method      string
+		endpoint    string
+		contentType string
+		params      *registry.SearchParams
+		resStatus   int
+	}{
+		{"GET", "/search", "application/json", &registry.SearchParams{"abc", 0, 100}, 200},
+	}
 
-  }{
-    {"GET", "/search", "application/json", &registry.SearchParams{"abc", 0, 100}, 400},
-  }
-
-  for i, c := range cases {
-    req, err := http.NewRequest(c.method, fmt.Sprintf("%s%s", s.URL, c.endpoint), nil)
-    if err != nil {
-      t.Errorf("case %d error creating request: %s", i, err.Error())
-      continue
-    }
-    if c.contentType != "" {
-      req.Header.Set("Content-Type", c.contentType)
-    }
-    if c.params != nil {
-      data, err := json.Marshal(c.params)
-      if err != nil {
-        t.Errorf("error marshaling json body: %s", err.Error())
-        return
-      }
-      req.Body = ioutil.NopCloser(bytes.NewReader([]byte(data)))
-    }
-    res, err := http.DefaultClient.Do(req)
-    if res.StatusCode != c.resStatus {
-      t.Errorf("case %d res status mismatch. expected: %d, got: %d", i, c.resStatus, res.StatusCode)
-      continue
-    }
-  }
+	for i, c := range cases {
+		req, err := http.NewRequest(c.method, fmt.Sprintf("%s%s", s.URL, c.endpoint), nil)
+		if err != nil {
+			t.Errorf("case %d error creating request: %s", i, err.Error())
+			continue
+		}
+		if c.contentType != "" {
+			req.Header.Set("Content-Type", c.contentType)
+		}
+		if c.params != nil {
+			data, err := json.Marshal(c.params)
+			if err != nil {
+				t.Errorf("error marshaling json body: %s", err.Error())
+				return
+			}
+			req.Body = ioutil.NopCloser(bytes.NewReader([]byte(data)))
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Errorf("case %d unexpected error: %s", i, err)
+			continue
+		}
+		if res.StatusCode != c.resStatus {
+			t.Errorf("case %d res status mismatch. expected: %d, got: %d", i, c.resStatus, res.StatusCode)
+			continue
+		}
+	}
 }

--- a/regserver/mock/server.go
+++ b/regserver/mock/server.go
@@ -10,12 +10,13 @@ import (
 	"github.com/qri-io/registry/regserver/handlers"
 )
 
-var nilSearch registry.NilSearch
+// var nilSearch registry.NilSearch
+var mockSearch = &registry.MockSearch{}
 
 // NewMockServer creates an in-memory mock server without any access protection and
 // a registry client to match
 func NewMockServer() (*regclient.Client, *httptest.Server) {
-	s := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), registry.NewMemDatasets(), nilSearch))
+	s := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), registry.NewMemProfiles(), registry.NewMemDatasets(), mockSearch))
 	c := regclient.NewClient(&regclient.Config{Location: s.URL})
 	return c, s
 }

--- a/search.go
+++ b/search.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Searchable is an interface for supporting search
@@ -33,4 +34,25 @@ type NilSearch bool
 // Search returns an error indicating that search is not supported
 func (ns NilSearch) Search(p SearchParams) ([]Result, error) {
 	return nil, ErrSearchNotSupported
+}
+
+// MockSearch wraps a registry.Datasets and is used for testing purposes only
+type MockSearch struct {
+	Datasets Datasets
+}
+
+// Search is a trivial search implementation used for testing
+func (ms MockSearch) Search(p SearchParams) (results []Result, err error) {
+	ms.Datasets.Range(func(key string, ds *Dataset) bool {
+		dsname := ""
+		if ds.Meta != nil {
+			dsname = strings.ToLower(ds.Meta.Title)
+		}
+		if strings.Contains(dsname, strings.ToLower(p.Q)) {
+			result := &Result{Value: ds}
+			results = append(results, *result)
+		}
+		return false
+	})
+	return results, nil
 }


### PR DESCRIPTION
- the refactoring `doJSONSearchReq` in regclient/search.go was in a previous approved pr (I forgot that it had been approved and didn't ever merge it).  
- if this is approved, will close the other open pr without merging it