### PR TITLE
feat(reputation): most basic handler added for `/reputation` endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - run:
           name: install test deps
-          command: go get github.com/jstemmer/go-junit-report github.com/golang/lint/golint
+          command: go get github.com/jstemmer/go-junit-report golang.org/x/lint/golint
       - run: 
           name: Run Lint Tests
           command: golint -set_exit_status ./...

--- a/regclient/reputation.go
+++ b/regclient/reputation.go
@@ -1,0 +1,62 @@
+package regclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/qri-io/registry"
+)
+
+// GetReputation gets the reputation of a profile using the ProfileID
+func (c Client) GetReputation(id string) (*registry.Reputation, error) {
+	repReq := registry.NewReputation(id)
+	rep, err := c.doJSONReputationReq("GET", repReq)
+	if err != nil {
+		return nil, err
+	}
+	return rep, nil
+}
+
+// doJSONReputationReq is a common wrapper for /reputation endpoint requests
+func (c Client) doJSONReputationReq(method string, rep *registry.Reputation) (*registry.Reputation, error) {
+	if c.cfg.Location == "" {
+		return nil, ErrNoRegistry
+	}
+
+	data, err := json.Marshal(rep)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/reputation", c.cfg.Location), bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	env := struct {
+		Data *registry.Reputation
+		Meta struct {
+			Error  string
+			Status string
+			Code   int
+		}
+	}{}
+
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error %d: %s", res.StatusCode, env.Meta.Error)
+	}
+
+	return env.Data, nil
+
+}

--- a/regclient/reputation.go
+++ b/regclient/reputation.go
@@ -10,17 +10,17 @@ import (
 )
 
 // GetReputation gets the reputation of a profile using the ProfileID
-func (c Client) GetReputation(id string) (*registry.Reputation, error) {
+func (c Client) GetReputation(id string) (*registry.ReputationResponse, error) {
 	repReq := registry.NewReputation(id)
-	rep, err := c.doJSONReputationReq("GET", repReq)
+	res, err := c.doJSONReputationReq("GET", repReq)
 	if err != nil {
 		return nil, err
 	}
-	return rep, nil
+	return res, nil
 }
 
 // doJSONReputationReq is a common wrapper for /reputation endpoint requests
-func (c Client) doJSONReputationReq(method string, rep *registry.Reputation) (*registry.Reputation, error) {
+func (c Client) doJSONReputationReq(method string, rep *registry.Reputation) (*registry.ReputationResponse, error) {
 	if c.cfg.Location == "" {
 		return nil, ErrNoRegistry
 	}
@@ -41,7 +41,7 @@ func (c Client) doJSONReputationReq(method string, rep *registry.Reputation) (*r
 	}
 
 	env := struct {
-		Data *registry.Reputation
+		Data *registry.ReputationResponse
 		Meta struct {
 			Error  string
 			Status string

--- a/regclient/reputation_test.go
+++ b/regclient/reputation_test.go
@@ -42,8 +42,8 @@ func TestReputationRequests(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if 0 != rep.Reputation() {
-		t.Errorf("reputation value not equal: expect -1, got %d", rep.Reputation())
+	if 1 != rep.Reputation() {
+		t.Errorf("reputation value not equal: expect 1, got %d", rep.Reputation())
 	}
 	if memRs.Len() != 2 {
 		t.Errorf("reputations list should equal 2, got %d", memRs.Len())

--- a/regclient/reputation_test.go
+++ b/regclient/reputation_test.go
@@ -1,0 +1,51 @@
+package regclient
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qri-io/registry"
+	"github.com/qri-io/registry/regserver/handlers"
+)
+
+func TestReputationRequests(t *testing.T) {
+	profileID := "my_id"
+	profileID2 := "my_second_id"
+	memRs := registry.NewMemReputations()
+	newRep := registry.NewReputation(profileID)
+	newRep.SetReputation(-1)
+	err := memRs.Add(newRep)
+	if err != nil {
+		t.Error(err)
+	}
+
+	reg := registry.Registry{
+		Reputations: memRs,
+	}
+	ts := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), reg))
+	c := NewClient(&Config{
+		Location: ts.URL,
+	})
+
+	rep, err := c.GetReputation(profileID)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if -1 != rep.Reputation() {
+		t.Error(fmt.Errorf("reputation value not equal: expect -1, got %d", rep.Reputation()))
+	}
+
+	rep, err = c.GetReputation(profileID2)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if 0 != rep.Reputation() {
+		t.Errorf("reputation value not equal: expect -1, got %d", rep.Reputation())
+	}
+	if memRs.Len() != 2 {
+		t.Errorf("reputations list should equal 2, got %d", memRs.Len())
+	}
+}

--- a/regclient/reputation_test.go
+++ b/regclient/reputation_test.go
@@ -1,9 +1,9 @@
 package regclient
 
 import (
-	"fmt"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/qri-io/registry"
 	"github.com/qri-io/registry/regserver/handlers"
@@ -28,23 +28,37 @@ func TestReputationRequests(t *testing.T) {
 		Location: ts.URL,
 	})
 
-	rep, err := c.GetReputation(profileID)
+	res, err := c.GetReputation(profileID)
 	if err != nil {
 		t.Error(err)
 		return
-	}
-	if -1 != rep.Reputation() {
-		t.Error(fmt.Errorf("reputation value not equal: expect -1, got %d", rep.Reputation()))
 	}
 
-	rep, err = c.GetReputation(profileID2)
+	rep := res.Reputation
+	ttl := res.Expiration
+	if -1 != rep.Reputation() {
+		t.Errorf("reputation value not equal: expect -1, got %d\n", rep.Reputation())
+	}
+
+	if ttl != time.Hour*24 {
+		t.Errorf("reputation expiration not equal: expect 24 hours got %d\n", ttl)
+	}
+
+	res, err = c.GetReputation(profileID2)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+
+	rep = res.Reputation
+	ttl = res.Expiration
 	if 1 != rep.Reputation() {
 		t.Errorf("reputation value not equal: expect 1, got %d", rep.Reputation())
 	}
+	if ttl != time.Hour*24 {
+		t.Errorf("reputation expiration not equal: expect 24 hours got %d\n", ttl)
+	}
+
 	if memRs.Len() != 2 {
 		t.Errorf("reputations list should equal 2, got %d", memRs.Len())
 	}

--- a/registry.go
+++ b/registry.go
@@ -24,8 +24,9 @@ package registry
 
 // Registry a collection of interfaces that together form a registry service
 type Registry struct {
-	Profiles Profiles
-	Datasets Datasets
-	Pinset   Pinset
-	Search   Searchable
+	Profiles    Profiles
+	Datasets    Datasets
+	Pinset      Pinset
+	Search      Searchable
+	Reputations Reputations
 }

--- a/regserver/handlers/reputation.go
+++ b/regserver/handlers/reputation.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/registry"
+)
+
+// NewReputationHandler creates a profile handler func that operates on a *registry.Reputations
+func NewReputationHandler(rs registry.Reputations) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		rep := &registry.Reputation{}
+		switch r.Header.Get("Content-Type") {
+		case "application/json":
+			if err := json.NewDecoder(r.Body).Decode(rep); err != nil {
+				apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
+				return
+			}
+		default:
+			err := fmt.Errorf("Content-Type must be application/json")
+			apiutil.WriteErrResponse(w, http.StatusBadRequest, err)
+			return
+		}
+
+		switch r.Method {
+		case "GET":
+			var ok bool
+			// TODO: finesse
+			// For now, if no reputation is found, create a new reputation
+			// add it to the list of reputations, and return the new reputation
+			profileID := rep.ProfileID
+			if profileID != "" {
+				rep, ok = rs.Load(profileID)
+				if !ok {
+					rep = registry.NewReputation(profileID)
+					rs.Add(rep)
+				}
+			}
+		default:
+			apiutil.NotFoundHandler(w, r)
+			return
+		}
+		apiutil.WriteResponse(w, rep)
+	}
+}

--- a/regserver/handlers/reputation.go
+++ b/regserver/handlers/reputation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/datatogether/api/apiutil"
 	"github.com/qri-io/registry"
@@ -43,6 +44,10 @@ func NewReputationHandler(rs registry.Reputations) http.HandlerFunc {
 			apiutil.NotFoundHandler(w, r)
 			return
 		}
-		apiutil.WriteResponse(w, rep)
+		res := registry.ReputationResponse{
+			Reputation: rep,
+			Expiration: time.Hour * 24,
+		}
+		apiutil.WriteResponse(w, res)
 	}
 }

--- a/regserver/handlers/reputation_test.go
+++ b/regserver/handlers/reputation_test.go
@@ -40,7 +40,7 @@ func TestReputation(t *testing.T) {
 	s := httptest.NewServer(NewRoutes(NewNoopProtector(), registry.Registry{Reputations: memReps}))
 
 	type env struct {
-		Data *registry.Reputation
+		Data *registry.ReputationResponse
 		Meta struct {
 			Code int
 		}
@@ -97,12 +97,15 @@ func TestReputation(t *testing.T) {
 				continue
 			}
 
-			if c.reputation.ProfileID != e.Data.ProfileID {
-				t.Errorf("case %d reputation profileID mismatch. expected: %s, got:%s", i, c.reputation.ProfileID, e.Data.ProfileID)
+			res := e.Data
+			rep := res.Reputation
+
+			if c.reputation.ProfileID != rep.ProfileID {
+				t.Errorf("case %d reputation profileID mismatch. expected: %s, got:%s", i, c.reputation.ProfileID, rep.ProfileID)
 			}
 
-			if c.reputation.Rep != e.Data.Rep {
-				t.Errorf("case %d Reputation mismatch. expected: %d, got: %d", i, c.reputation.Rep, e.Data.Rep)
+			if c.reputation.Rep != rep.Rep {
+				t.Errorf("case %d Reputation mismatch. expected: %d, got: %d", i, c.reputation.Rep, rep.Rep)
 			}
 		}
 	}

--- a/regserver/handlers/reputation_test.go
+++ b/regserver/handlers/reputation_test.go
@@ -15,7 +15,7 @@ import (
 func TestReputation(t *testing.T) {
 	freshRep := &registry.Reputation{
 		ProfileID: "freshRep",
-		Rep:       0,
+		Rep:       1,
 	}
 
 	badRep := &registry.Reputation{
@@ -25,7 +25,7 @@ func TestReputation(t *testing.T) {
 
 	goodRep := &registry.Reputation{
 		ProfileID: "goodRep",
-		Rep:       1,
+		Rep:       10,
 	}
 
 	memReps := registry.NewMemReputations()

--- a/regserver/handlers/reputation_test.go
+++ b/regserver/handlers/reputation_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qri-io/registry"
+)
+
+func TestReputation(t *testing.T) {
+	freshRep := &registry.Reputation{
+		ProfileID: "freshRep",
+		Rep:       0,
+	}
+
+	badRep := &registry.Reputation{
+		ProfileID: "badRep",
+		Rep:       -1,
+	}
+
+	goodRep := &registry.Reputation{
+		ProfileID: "goodRep",
+		Rep:       1,
+	}
+
+	memReps := registry.NewMemReputations()
+	memReps.Add(badRep)
+	memReps.Add(goodRep)
+
+	if memReps.Len() != 2 {
+		t.Errorf("error adding initial reps to in memory reputations list")
+		return
+	}
+
+	s := httptest.NewServer(NewRoutes(NewNoopProtector(), registry.Registry{Reputations: memReps}))
+
+	type env struct {
+		Data *registry.Reputation
+		Meta struct {
+			Code int
+		}
+	}
+
+	cases := []struct {
+		method      string
+		endpoint    string
+		contentType string
+		profileID   string
+		resStatus   int
+		reputation  *registry.Reputation
+	}{
+		{"BAD_METHOD", "/reputation", "", "", http.StatusBadRequest, nil},
+		{"BAD_METHOD", "/reputation", "application/json", "", http.StatusBadRequest, nil},
+		{"BAD_METHOD", "/reputation", "application/json", "my_id", http.StatusNotFound, nil},
+		{"GET", "/reputation", "", "", http.StatusBadRequest, nil},
+		{"GET", "/reputation", "application/json", "", http.StatusBadRequest, nil},
+		{"GET", "/reputation", "application/json", "freshRep", http.StatusOK, freshRep},
+		{"GET", "/reputation", "application/json", "badRep", http.StatusOK, badRep},
+		{"GET", "/reputation", "application/json", "goodRep", http.StatusOK, goodRep},
+	}
+
+	for i, c := range cases {
+		requestRep := registry.NewReputation(c.profileID)
+		req, err := http.NewRequest(c.method, fmt.Sprintf("%s%s", s.URL, c.endpoint), nil)
+		if err != nil {
+			t.Errorf("case %d error creating request: %s", i, err.Error())
+			continue
+		}
+
+		if c.contentType != "" {
+			req.Header.Set("Content-Type", c.contentType)
+		}
+		if c.profileID != "" {
+			data, err := json.Marshal(requestRep)
+			if err != nil {
+				t.Errorf("error marshaling json body: %s", err.Error())
+				return
+			}
+			req.Body = ioutil.NopCloser(bytes.NewReader([]byte(data)))
+		}
+
+		res, err := http.DefaultClient.Do(req)
+		if res.StatusCode != c.resStatus {
+			t.Errorf("case %d res status mismatch. expected: %d, got: %d", i, c.resStatus, res.StatusCode)
+			continue
+		}
+
+		if c.reputation != nil {
+			e := &env{}
+			if err := json.NewDecoder(res.Body).Decode(e); err != nil {
+				t.Errorf("case %d error reading response body: %s", i, err.Error())
+				continue
+			}
+
+			if c.reputation.ProfileID != e.Data.ProfileID {
+				t.Errorf("case %d reputation profileID mismatch. expected: %s, got:%s", i, c.reputation.ProfileID, e.Data.ProfileID)
+			}
+
+			if c.reputation.Rep != e.Data.Rep {
+				t.Errorf("case %d Reputation mismatch. expected: %d, got: %d", i, c.reputation.Rep, e.Data.Rep)
+			}
+		}
+	}
+}

--- a/regserver/handlers/routes.go
+++ b/regserver/handlers/routes.go
@@ -33,6 +33,14 @@ func NewRoutes(pro MethodProtector, reg registry.Registry) http.Handler {
 	if pinset := reg.Pinset; pinset != nil {
 		m.HandleFunc("/pins", logReq(NewPinsHandler(pinset)))
 	}
+	// TODO: we want to lay the groundwork for getting a peer's reputation
+	// on the registry. We know we need an endpoint `/reputation` that
+	// will respond with an integer. Qri will use that integer to determine
+	// how to treat the connection with that peer. For now, let's just return
+	// zero, and refactor in the future when we do a deep dive on reputation
+	m.HandleFunc("/reputation", (logReq(func(w http.ResponseWriter, r *http.Request) {
+		apiutil.WriteResponse(w, map[string]int{"reputation": 0})
+	})))
 
 	return m
 }

--- a/regserver/handlers/routes.go
+++ b/regserver/handlers/routes.go
@@ -33,14 +33,9 @@ func NewRoutes(pro MethodProtector, reg registry.Registry) http.Handler {
 	if pinset := reg.Pinset; pinset != nil {
 		m.HandleFunc("/pins", logReq(NewPinsHandler(pinset)))
 	}
-	// TODO: we want to lay the groundwork for getting a peer's reputation
-	// on the registry. We know we need an endpoint `/reputation` that
-	// will respond with an integer. Qri will use that integer to determine
-	// how to treat the connection with that peer. For now, let's just return
-	// zero, and refactor in the future when we do a deep dive on reputation
-	m.HandleFunc("/reputation", (logReq(func(w http.ResponseWriter, r *http.Request) {
-		apiutil.WriteResponse(w, map[string]int{"reputation": 0})
-	})))
+	if rs := reg.Reputations; rs != nil {
+		m.HandleFunc("/reputation", (logReq(NewReputationHandler(rs))))
+	}
 
 	return m
 }

--- a/reputation.go
+++ b/reputation.go
@@ -1,0 +1,40 @@
+package registry
+
+import (
+	"fmt"
+)
+
+// Reputation is record of the peers reputation on the network
+// This is a stub to be filled in later
+
+type Reputation struct {
+	ProfileID string
+	Rep       int
+}
+
+// NewReputation creates a new reputation. Reputations start at 0 for now
+func NewReputation(id string) *Reputation {
+	return &Reputation{
+		ProfileID: id,
+		Rep:       0,
+	}
+}
+
+// Validate is a sanity check that all required values are present
+func (r *Reputation) Validate() error {
+	if r.ProfileID == "" {
+		return fmt.Errorf("profileID is required")
+	}
+
+	return nil
+}
+
+// SetReputation sets the reputation of a given Reputation
+func (r *Reputation) SetReputation(reputation int) {
+	r.Rep = reputation
+}
+
+// Reputation gets the rep of a given Reputation
+func (r *Reputation) Reputation() int {
+	return r.Rep
+}

--- a/reputation.go
+++ b/reputation.go
@@ -5,8 +5,7 @@ import (
 )
 
 // Reputation is record of the peers reputation on the network
-// This is a stub to be filled in later
-
+// TODO: this is a stub that can and should be expanded
 type Reputation struct {
 	ProfileID string
 	Rep       int

--- a/reputation.go
+++ b/reputation.go
@@ -40,6 +40,7 @@ func (r *Reputation) Reputation() int {
 	return r.Rep
 }
 
+// ReputationResponse is the result of a request for a reputation
 type ReputationResponse struct {
 	Reputation *Reputation
 	Expiration time.Duration

--- a/reputation.go
+++ b/reputation.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"time"
 )
 
 // Reputation is record of the peers reputation on the network
@@ -37,4 +38,9 @@ func (r *Reputation) SetReputation(reputation int) {
 // Reputation gets the rep of a given Reputation
 func (r *Reputation) Reputation() int {
 	return r.Rep
+}
+
+type ReputationResponse struct {
+	Reputation *Reputation
+	Expiration time.Duration
 }

--- a/reputation.go
+++ b/reputation.go
@@ -11,11 +11,12 @@ type Reputation struct {
 	Rep       int
 }
 
-// NewReputation creates a new reputation. Reputations start at 0 for now
+// NewReputation creates a new reputation. Reputations start at 1 for now
+// REPUTATIONS MUST BE NON-ZERO NUMBERS
 func NewReputation(id string) *Reputation {
 	return &Reputation{
 		ProfileID: id,
-		Rep:       0,
+		Rep:       1,
 	}
 }
 

--- a/reputation_test.go
+++ b/reputation_test.go
@@ -1,0 +1,64 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestReputationValidate(t *testing.T) {
+	cases := []struct {
+		r   *Reputation
+		err string
+	}{
+		{&Reputation{}, "profileID is required"},
+		{&Reputation{ProfileID: "my_id"}, ""},
+		{&Reputation{ProfileID: "my_id", Rep: 0}, ""},
+	}
+
+	for i, c := range cases {
+		err := c.r.Validate()
+
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d err mismatch. expected: %s, got: %s", i, c.err, err)
+			continue
+		}
+	}
+
+}
+
+func TestReputationReputation(t *testing.T) {
+	cases := []struct {
+		r      *Reputation
+		expect int
+	}{
+		{&Reputation{}, 0},
+		{&Reputation{Rep: 0}, 0},
+		{&Reputation{Rep: 10}, 10},
+		{&Reputation{Rep: -1}, -1},
+	}
+	for i, c := range cases {
+		rep := c.r.Reputation()
+
+		if c.expect != rep {
+			t.Errorf("case %d reputation mismatch. expected: %d, got: %d", i, c.expect, rep)
+		}
+	}
+}
+
+func TestSetReputation(t *testing.T) {
+	cases := []struct {
+		r   *Reputation
+		set int
+	}{
+		{&Reputation{}, 10},
+		{&Reputation{Rep: -1}, 0},
+		{&Reputation{Rep: 5}, 5},
+		{&Reputation{Rep: 1}, -1},
+	}
+	for i, c := range cases {
+		c.r.SetReputation(c.set)
+
+		if c.r.Reputation() != c.set {
+			t.Errorf("case %d set reputation mismatch. expected: %d, got: %d", i, c.set, c.r.Reputation())
+		}
+	}
+}

--- a/reputations.go
+++ b/reputations.go
@@ -1,0 +1,109 @@
+package registry
+
+import (
+	"sort"
+	"sync"
+)
+
+// Reputations is the interface for working with a set of *Reputation's
+// Add, Load, Len, Range, and SortedRange should be
+// considered safe to hook up to public http endpoints, whereas
+// Delete & Store should only be exposed in administrative contexts
+type Reputations interface {
+	// Len returns the number of records in the set
+	Len() int
+	// Load fetches a profile from the list by key
+	Load(key string) (value *Reputation, ok bool)
+	// Range calls an iteration fuction on each element in the map until
+	// the end of the list is reached or iter returns true
+	Range(iter func(key string, r *Reputation) (brk bool))
+	// SortedRange is like range but with deterministic key ordering
+	SortedRange(iter func(key string, r *Reputation) (brk bool))
+	// Add adds the Reputation to the list of reputations
+	Add(r *Reputation) error
+
+	// Store adds an entry, bypassing the register process
+	// store is only exported for administrative use cases.
+	// most of the time callers should use Register instead
+	Store(key string, value *Reputation)
+	// Delete removes a record from the set at key
+	// Delete is only exported for administrative use cases.
+	// most of the time callers should use Deregister instead
+	Delete(key string)
+}
+
+type MemReputations struct {
+	sync.RWMutex
+	internal map[string]*Reputation
+}
+
+func NewMemReputations() *MemReputations {
+	return &MemReputations{
+		internal: make(map[string]*Reputation),
+	}
+}
+
+func (rs *MemReputations) Add(r *Reputation) error {
+	err := r.Validate()
+	if err != nil {
+		return err
+	}
+	rs.Store(r.ProfileID, r)
+	return nil
+}
+
+//
+func (rs *MemReputations) Len() int {
+	return len(rs.internal)
+}
+
+func (rs *MemReputations) Load(key string) (value *Reputation, ok bool) {
+	rs.RLock()
+	result, ok := rs.internal[key]
+	rs.RUnlock()
+	return result, ok
+}
+
+// Range calls an iteration fuction on each element in the map until
+// the end of the list is reached or iter returns true
+func (rs *MemReputations) Range(iter func(key string, r *Reputation) (brk bool)) {
+	rs.RLock()
+	defer rs.RUnlock()
+	for key, r := range rs.internal {
+		if iter(key, r) {
+			break
+		}
+	}
+}
+
+// SortedRange is like range but with deterministic key ordering
+func (rs *MemReputations) SortedRange(iter func(key string, r *Reputation) (brk bool)) {
+	rs.RLock()
+	defer rs.RUnlock()
+	keys := make([]string, len(rs.internal))
+	i := 0
+	for key := range rs.internal {
+		keys[i] = key
+		i++
+	}
+	sort.StringSlice(keys).Sort()
+	for _, key := range keys {
+		if iter(key, rs.internal[key]) {
+			break
+		}
+	}
+}
+
+// Delete removes a record from MemReputations at key
+func (rs *MemReputations) Delete(key string) {
+	rs.Lock()
+	delete(rs.internal, key)
+	rs.Unlock()
+}
+
+// Store adds an entry
+func (rs *MemReputations) Store(key string, value *Reputation) {
+	rs.Lock()
+	rs.internal[key] = value
+	rs.Unlock()
+}

--- a/reputations.go
+++ b/reputations.go
@@ -32,17 +32,22 @@ type Reputations interface {
 	Delete(key string)
 }
 
+// MemReputations is a map of reputation data safe for concurrent use
+// heavily inspired by sync.Map
 type MemReputations struct {
 	sync.RWMutex
 	internal map[string]*Reputation
 }
 
+// NewMemReputations allocates a new *MemReputations map
 func NewMemReputations() *MemReputations {
 	return &MemReputations{
 		internal: make(map[string]*Reputation),
 	}
 }
 
+// Add adds the reputation to the map of reputations
+// it Validates the reputation before adding it
 func (rs *MemReputations) Add(r *Reputation) error {
 	err := r.Validate()
 	if err != nil {
@@ -52,11 +57,12 @@ func (rs *MemReputations) Add(r *Reputation) error {
 	return nil
 }
 
-//
+// Len returns the number of records in the map
 func (rs *MemReputations) Len() int {
 	return len(rs.internal)
 }
 
+// Load fetches a reputation from the list by key
 func (rs *MemReputations) Load(key string) (value *Reputation, ok bool) {
 	rs.RLock()
 	result, ok := rs.internal[key]


### PR DESCRIPTION
basically fulfills #15 without having to really make any decisions right now.

Enough to get by for now, unless we want something less placeholder-y 