### PR TITLE
test(mocks): expand mock test funcs

### DIFF
--- a/pinset_test.go
+++ b/pinset_test.go
@@ -1,0 +1,58 @@
+package registry
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-crypto"
+)
+
+func comparePinRequest(a, b *PinRequest) error {
+	if a.ProfileID != b.ProfileID {
+		return fmt.Errorf("ProfileID mismatch: %s != %s", a.ProfileID, b.ProfileID)
+	}
+	if a.Signature != b.Signature {
+		return fmt.Errorf("Signature mismatch: %s != %s", a.Signature, b.Signature)
+	}
+	if a.Path != b.Path {
+		return fmt.Errorf("Path mismatch: %s != %s", a.Path, b.Path)
+	}
+	if len(a.PeerAddresses) != len(b.PeerAddresses) {
+		return fmt.Errorf("PeerAddresses length mismatch: %d != %d", len(a.PeerAddresses), len(b.PeerAddresses))
+	}
+	return nil
+}
+
+func TestNewPinRequest(t *testing.T) {
+	cases := []struct {
+		path, base64Key string
+		addrs           []string
+		res             PinRequest
+		err             string
+	}{
+		// TODO
+	}
+
+	for i, c := range cases {
+		data, err := base64.StdEncoding.DecodeString(c.base64Key)
+		if err != nil {
+			t.Fatalf("case %d key base64 encoding error: %s", i, err.Error())
+		}
+		pk, err := crypto.UnmarshalPrivateKey(data)
+		if err != nil {
+			t.Fatalf("case %d pk unmarshall error: %s", i, err.Error())
+		}
+		pr, err := NewPinRequest(c.path, pk, c.addrs)
+
+		if !(err == nil || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if err = comparePinRequest(&c.res, pr); err != nil {
+			t.Errorf("case %d: %s", i, err.Error())
+			continue
+		}
+	}
+}

--- a/regserver/mock/server.go
+++ b/regserver/mock/server.go
@@ -13,30 +13,33 @@ import (
 // NewMockServer creates an in-memory mock server without any access protection and
 // a registry client to match
 func NewMockServer() (*regclient.Client, *httptest.Server) {
-	ds := registry.NewMemDatasets()
-	reg := registry.Registry{
-		Profiles: registry.NewMemProfiles(),
-		Datasets: ds,
-		Search:   registry.MockSearch{ds},
-	}
+	return NewMockServerRegistry(NewMemRegistry())
+}
+
+// NewMockServerRegistry creates a mock server & client with a passed-in registry
+func NewMockServerRegistry(reg registry.Registry) (*regclient.Client, *httptest.Server) {
 	s := httptest.NewServer(handlers.NewRoutes(handlers.NewNoopProtector(), reg))
 	c := regclient.NewClient(&regclient.Config{Location: s.URL})
 	return c, s
 }
 
-// NewMockServerWithMemPinset creates an in-memory mock server without any access protection and
-// a registry client to match, but also adds an in-memory pinset to test the /pin endpoint
-func NewMockServerWithMemPinset() (*regclient.Client, *httptest.Server) {
-	protek := handlers.NewNoopProtector()
+// NewMemRegistry creates a new in-memory registry
+func NewMemRegistry() registry.Registry {
+	return registry.Registry{
+		Profiles: registry.NewMemProfiles(),
+		Datasets: registry.NewMemDatasets(),
+	}
+}
+
+// NewMemRegistryPinset creates an in-memory registry without any access protection,
+// a registry client, and an in-memory pinset
+func NewMemRegistryPinset() registry.Registry {
 	prof := registry.NewMemProfiles()
 	ds := registry.NewMemDatasets()
-	reg := registry.Registry{
+	return registry.Registry{
 		Profiles: prof,
 		Datasets: ds,
 		Pinset:   &registry.MemPinset{Profiles: prof},
-		Search:   registry.MockSearch{ds},
+		Search:   registry.MockSearch{Datasets: ds},
 	}
-	s := httptest.NewServer(handlers.NewRoutes(protek, reg))
-	c := regclient.NewClient(&regclient.Config{Location: s.URL})
-	return c, s
 }

--- a/regserver/mock/server_test.go
+++ b/regserver/mock/server_test.go
@@ -1,0 +1,11 @@
+package mock
+
+import (
+	"testing"
+)
+
+func TestMockServer(t *testing.T) {
+	NewMockServer()
+	NewMockServerRegistry(NewMemRegistry())
+	NewMockServerRegistry(NewMemRegistryPinset())
+}


### PR DESCRIPTION
it's easier to run tests in Qri if you can allocate & keep a mock registry in the test. Expanded mock creation funcs to support this.