### PR TITLE
fix(dataset): support getting dataset info

### DIFF
--- a/ns/context.go
+++ b/ns/context.go
@@ -1,0 +1,54 @@
+package ns
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// QriCtxKey defines a distinct type for
+// keys for context values should always use custom
+// types to avoid collissions.
+// see comment on context.WithValue for more info
+type QriCtxKey string
+
+// RefCtxKey is the key for adding a dataset reference
+// to a context.Context
+const RefCtxKey QriCtxKey = "datasetRef"
+
+// RefFromReq examines the path element of a request URL
+// to
+func RefFromReq(r *http.Request) (Ref, error) {
+	if r.URL.String() == "" || r.URL.Path == "" {
+		return Ref{}, nil
+	}
+	return RefFromHTTPPath(r.URL.Path)
+}
+
+// RefFromHTTPPath parses a path and returns a datasetRef
+func RefFromHTTPPath(path string) (Ref, error) {
+	refstr := HTTPPathToQriPath(path)
+	return ParseRef(refstr)
+}
+
+// RefFromCtx extracts a Dataset reference from a given
+// context if one is set, returning nil otherwise
+func RefFromCtx(ctx context.Context) Ref {
+	iface := ctx.Value(RefCtxKey)
+	if ref, ok := iface.(Ref); ok {
+		return ref
+	}
+	return Ref{}
+}
+
+// HTTPPathToQriPath converts a http path to a
+// qri path
+func HTTPPathToQriPath(path string) string {
+	paramIndex := strings.Index(path, "?")
+	if paramIndex != -1 {
+		path = path[:paramIndex]
+	}
+	path = strings.Replace(path, "/at", "@", 1)
+	path = strings.TrimPrefix(path, "/")
+	return path
+}

--- a/ns/context_test.go
+++ b/ns/context_test.go
@@ -1,0 +1,45 @@
+package ns
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+func TestRefFromReq(t *testing.T) {
+	cases := []struct {
+		url      string
+		expected Ref
+		err      string
+	}{
+		{"http://localhost:2503/peername", Ref{Peername: "peername"}, ""},
+		{"http://localhost:2503/peername?limit=10&offset=2", Ref{Peername: "peername"}, ""},
+		{"http://localhost:2503/peername/datasetname", Ref{Peername: "peername", Name: "datasetname"}, ""},
+		{"http://localhost:2503/peername/datasetname/at/ipfs/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD", Ref{Peername: "peername", Name: "datasetname", Path: "/ipfs/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD"}, ""},
+		{"http://localhost:2503/peername/datasetname/at/ntwk/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD", Ref{Peername: "peername", Name: "datasetname", Path: "/ntwk/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD"}, ""},
+		{"http://localhost:2503/peername/datasetname/at/map/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD/dataset.json", Ref{Peername: "peername", Name: "datasetname", Path: "/map/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD"}, ""},
+		{"http://localhost:2503/peername/datasetname/at/ipfs/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD", Ref{Peername: "peername", Name: "datasetname", Path: "/ipfs/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD"}, ""},
+		{"http://google.com:8000/peername/datasetname/at/ipfs/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD", Ref{Peername: "peername", Name: "datasetname", Path: "/ipfs/QmdWJ7RnFj3SdWW85mR4AYP17C8dRPD9eUPyTqUxVyGMgD"}, ""},
+		{"http://google.com:8000/peername", Ref{Peername: "peername"}, ""},
+		// {"http://google.com/peername", Ref{Peername: "peername"}, ""},
+		{"/peername", Ref{Peername: "peername"}, ""},
+		{"http://www.fkjhdekaldschjxilujkjkjknwjkn.org/peername/datasetname/", Ref{Peername: "peername", Name: "datasetname"}, ""},
+		{"http://example.com", Ref{}, ""},
+		{"", Ref{}, ""},
+	}
+
+	for i, c := range cases {
+		r, err := http.NewRequest("GET", c.url, bytes.NewReader(nil))
+		if err != nil {
+			t.Errorf("case %d, error making request: %s", i, err)
+		}
+		got, err := RefFromReq(r)
+		if (c.err != "" && err == nil) || (err != nil && c.err != err.Error()) {
+			t.Errorf("case %d, error mismatch: expected '%s' but got '%s'", i, c.err, err)
+			continue
+		}
+		if err := CompareRef(got, c.expected); err != nil {
+			t.Errorf("case %d: %s", i, err.Error())
+		}
+	}
+}

--- a/ns/ref.go
+++ b/ns/ref.go
@@ -1,0 +1,280 @@
+// Package ns defines the qri dataset naming system
+// This package is currently an experiment while we try to settle the distinction
+// between a dataset.datasetPod and a reference. This code is extracted from
+//  github.com/qri-io/qri/repo/ref.go
+//
+// This package will either move to a new location or be removed entirely
+// before 2019-04-01
+//
+// initial RFC is here: https://github.com/qri-io/rfcs/blob/master/text/0006-dataset_naming.md
+package ns
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mr-tron/base58"
+	multihash "github.com/multiformats/go-multihash"
+)
+
+var (
+	// ErrEmptyRef indicates that the given reference is empty
+	ErrEmptyRef = fmt.Errorf("repo: empty dataset reference")
+)
+
+// Ref encapsulates a reference to a dataset. This needs to exist to bind
+// ways of referring to a dataset to a dataset itself, as datasets can't easily
+// contain their own hash information, and names are unique on a per-repository
+// basis.
+// It's tempting to think this needs to be "bigger", supporting more fields,
+// keep in mind that if the information is important at all, it should
+// be stored as metadata within the dataset itself.
+type Ref struct {
+	// Peername of dataset owner
+	Peername string `json:"peername,omitempty"`
+	// ProfileID of dataset owner
+	ProfileID string `json:"profileID,omitempty"`
+	// Unique name reference for this dataset
+	Name string `json:"name,omitempty"`
+	// Content-addressed path for this dataset
+	Path string `json:"path,omitempty"`
+}
+
+// String implements the Stringer interface for Ref
+func (r Ref) String() (s string) {
+	s = r.AliasString()
+	if r.ProfileID != "" || r.Path != "" {
+		s += "@"
+	}
+	if r.ProfileID != "" {
+		s += r.ProfileID
+	}
+	if r.Path != "" {
+		s += r.Path
+	}
+	return
+}
+
+// AliasString returns the alias components of a Ref as a string
+func (r Ref) AliasString() (s string) {
+	s = r.Peername
+	if r.Name != "" {
+		s += "/" + r.Name
+	}
+	return
+}
+
+// Match checks returns true if Peername and Name are equal,
+// and/or path is equal
+func (r Ref) Match(b Ref) bool {
+	// fmt.Printf("\nr.Peername: %s b.Peername: %s\n", r.Peername, b.Peername)
+	// fmt.Printf("\nr.Name: %s b.Name: %s\n", r.Name, b.Name)
+	return (r.Path != "" && b.Path != "" && r.Path == b.Path) || (r.ProfileID == b.ProfileID || r.Peername == b.Peername) && r.Name == b.Name
+}
+
+// Equal returns true only if Peername Name and Path are equal
+func (r Ref) Equal(b Ref) bool {
+	return r.Peername == b.Peername && r.ProfileID == b.ProfileID && r.Name == b.Name && r.Path == b.Path
+}
+
+// IsPeerRef returns true if only Peername is set
+func (r Ref) IsPeerRef() bool {
+	return (r.Peername != "" || r.ProfileID != "") && r.Name == "" && r.Path == ""
+}
+
+// IsEmpty returns true if none of it's fields are set
+func (r Ref) IsEmpty() bool {
+	return r.Equal(Ref{})
+}
+
+// MustParseRef panics if the reference is invalid. Useful for testing
+func MustParseRef(refstr string) Ref {
+	ref, err := ParseRef(refstr)
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
+// ParseRef decodes a dataset reference from a string value
+// It’s possible to refer to a dataset in a number of ways.
+// The full definition of a dataset reference is as follows:
+//     dataset_reference = peer_name/dataset_name@peer_id/network/hash
+//
+// we swap in defaults as follows, all of which are represented as
+// empty strings:
+//     network - defaults to /ipfs/
+//     hash - tip of version history (latest known commit)
+//
+// these defaults are currently enforced by convention.
+// TODO - make Dataset Ref parsing the responisiblity of the repo.Repo
+// interface, replacing empty strings with actual defaults
+//
+// dataset names & hashes are disambiguated by checking if the input
+// parses to a valid multihash after base58 decoding.
+// through defaults & base58 checking the following should all parse:
+//     peer_name/dataset_name
+//     /network/hash
+//     peername
+//     peer_id
+//     @peer_id
+//     @peer_id/network/hash
+//
+// see tests for more exmples
+//
+// TODO - add validation that prevents peernames from being
+// valid base58 multihashes and makes sure hashes are actually valid base58 multihashes
+// TODO - figure out how IPFS CID's play into this
+func ParseRef(ref string) (Ref, error) {
+	if ref == "" {
+		return Ref{}, ErrEmptyRef
+	}
+
+	var (
+		// nameRefString string
+		dsr = Ref{}
+		err error
+	)
+
+	// if there is an @ symbol, we are dealing with a Ref
+	// with an identifier
+	atIndex := strings.Index(ref, "@")
+
+	if atIndex != -1 {
+
+		dsr.Peername, dsr.Name = parseAlias(ref[:atIndex])
+		dsr.ProfileID, dsr.Path, err = parseIdentifiers(ref[atIndex+1:])
+
+	} else {
+
+		var peername, datasetname, pid bool
+		toks := strings.Split(ref, "/")
+
+		for i, tok := range toks {
+			if isBase58Multihash(tok) {
+				// first hash we encounter is a peerID
+				if !pid {
+					dsr.ProfileID = tok
+					pid = true
+					continue
+				}
+
+				if !isBase58Multihash(toks[i-1]) {
+					dsr.Path = fmt.Sprintf("/%s/%s", toks[i-1], strings.Join(toks[i:], "/"))
+				} else {
+					dsr.Path = fmt.Sprintf("/ipfs/%s", strings.Join(toks[i:], "/"))
+				}
+				break
+			}
+
+			if !peername {
+				dsr.Peername = tok
+				peername = true
+				continue
+			}
+
+			if !datasetname {
+				dsr.Name = tok
+				datasetname = true
+				continue
+			}
+
+			dsr.Path = strings.Join(toks[i:], "/")
+			break
+		}
+	}
+
+	if dsr.ProfileID == "" && dsr.Peername == "" && dsr.Name == "" && dsr.Path == "" {
+		err = fmt.Errorf("malformed Ref string: %s", ref)
+		return dsr, err
+	}
+
+	// if dsr.ProfileID != "" {
+	// 	if !isBase58Multihash(dsr.ProfileID) {
+	// 		err = fmt.Errorf("invalid ProfileID: '%s'", dsr.ProfileID)
+	// 		return dsr, err
+	// 	}
+	// }
+
+	return dsr, err
+}
+
+func parseAlias(alias string) (peer, dataset string) {
+	for i, tok := range strings.Split(alias, "/") {
+		switch i {
+		case 0:
+			peer = tok
+		case 1:
+			dataset = tok
+		}
+	}
+	return
+}
+
+func parseIdentifiers(ids string) (profileID, path string, err error) {
+
+	toks := strings.Split(ids, "/")
+	switch len(toks) {
+	case 0:
+		err = fmt.Errorf("malformed Ref identifier: %s", ids)
+	case 1:
+		if toks[0] != "" {
+			profileID = toks[0]
+
+			return
+		}
+	case 2:
+		profileID = toks[0]
+
+		if isBase58Multihash(toks[0]) && isBase58Multihash(toks[1]) {
+			toks[1] = fmt.Sprintf("/ipfs/%s", toks[1])
+		}
+
+		path = toks[1]
+	default:
+		profileID = toks[0]
+
+		path = fmt.Sprintf("/%s/%s", toks[1], toks[2])
+		return
+	}
+
+	return
+}
+
+// TODO - this could be more robust?
+func stripProtocol(ref string) string {
+	if strings.HasPrefix(ref, "/ipfs/") {
+		return ref[len("/ipfs/"):]
+	}
+	return ref
+}
+
+func isBase58Multihash(hash string) bool {
+	data, err := base58.Decode(hash)
+	if err != nil {
+		return false
+	}
+	if _, err := multihash.Decode(data); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// CompareRef compares two Dataset Refs, returning an error
+// describing any difference between the two references
+func CompareRef(a, b Ref) error {
+	if a.ProfileID != b.ProfileID {
+		return fmt.Errorf("PeerID mismatch. %s != %s", a.ProfileID, b.ProfileID)
+	}
+	if a.Peername != b.Peername {
+		return fmt.Errorf("Peername mismatch. %s != %s", a.Peername, b.Peername)
+	}
+	if a.Name != b.Name {
+		return fmt.Errorf("Name mismatch. %s != %s", a.Name, b.Name)
+	}
+	if a.Path != b.Path {
+		return fmt.Errorf("Path mismatch. %s != %s", a.Path, b.Path)
+	}
+	return nil
+}

--- a/ns/ref_test.go
+++ b/ns/ref_test.go
@@ -1,0 +1,327 @@
+package ns
+
+import (
+	"testing"
+)
+
+var cases = []struct {
+	ref         Ref
+	String      string
+	AliasString string
+}{
+	{Ref{
+		Peername: "peername",
+	}, "peername", "peername"},
+	{Ref{
+		Peername: "peername",
+		Name:     "datasetname",
+	}, "peername/datasetname", "peername/datasetname"},
+
+	{Ref{
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}, "@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", ""},
+	{Ref{
+		Path: "/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1",
+	}, "@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", ""},
+
+	{Ref{
+		Peername:  "peername",
+		Name:      "datasetname",
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}, "peername/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", "peername/datasetname"},
+	{Ref{
+		Peername:  "peername",
+		Name:      "datasetname",
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+		Path:      "/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1",
+	}, "peername/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "peername/datasetname"},
+
+	{Ref{
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+		Peername:  "lucille",
+	}, "lucille@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", "lucille"},
+	{Ref{
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+		Peername:  "lucille",
+		Name:      "ball",
+		Path:      "/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1",
+	}, "lucille/ball@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "lucille/ball"},
+
+	{Ref{
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+		Peername:  "bad_name",
+	}, "bad_name@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", "bad_name"},
+	// TODO - this used to be me@badId, which isn't very useful, but at least provided coding parity
+	// might be worth revisiting
+	{Ref{
+		ProfileID: "badID",
+		Peername:  "me",
+	}, "me@badID", "me"},
+}
+
+func TestRefString(t *testing.T) {
+	for i, c := range cases {
+		if c.ref.String() != c.String {
+			t.Errorf("case %d:\n%s\n%s", i, c.ref.String(), c.String)
+			continue
+		}
+	}
+}
+
+func TestRefAliasString(t *testing.T) {
+	for i, c := range cases {
+		if c.ref.AliasString() != c.AliasString {
+			t.Errorf("case %d:\n%s\n%s", i, c.ref.AliasString(), c.AliasString)
+			continue
+		}
+	}
+}
+
+func TestParseRef(t *testing.T) {
+	peernameRef := Ref{
+		Peername: "peername",
+	}
+
+	nameRef := Ref{
+		Peername: "peername",
+		Name:     "datasetname",
+	}
+
+	peerIDRef := Ref{
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}
+
+	idNameRef := Ref{
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+		Name:      "datasetname",
+	}
+
+	idFullRef := Ref{
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+		Name:      "datasetname",
+		Path:      "/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}
+
+	idFullIPFSRef := Ref{
+		Name:      "datasetname",
+		ProfileID: "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+		Path:      "/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}
+
+	fullRef := Ref{
+		Peername: "peername",
+		Name:     "datasetname",
+		Path:     "/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}
+
+	fullIPFSRef := Ref{
+		Peername: "peername",
+		Name:     "datasetname",
+		Path:     "/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}
+
+	pathOnlyRef := Ref{
+		Path: "/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}
+
+	ipfsOnlyRef := Ref{
+		Path: "/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y",
+	}
+
+	mapRef := Ref{
+		Path: "/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC",
+	}
+
+	cases := []struct {
+		input  string
+		expect Ref
+		err    string
+	}{
+		{"", Ref{}, "repo: empty dataset reference"},
+		{"peername/", peernameRef, ""},
+		{"peername", peernameRef, ""},
+
+		{"QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/", peerIDRef, ""},
+		{"/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", peerIDRef, ""},
+
+		{"peername/datasetname/", nameRef, ""},
+		{"peername/datasetname", nameRef, ""},
+		{"peername/datasetname/@", nameRef, ""},
+		{"peername/datasetname@", nameRef, ""},
+
+		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idNameRef, ""},
+		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/", idNameRef, ""},
+		{"/datasetname/@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idNameRef, ""},
+
+		{"peername/datasetname/@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", fullRef, ""},
+		{"peername/datasetname@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", fullRef, ""},
+
+		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullRef, ""},
+		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullRef, ""}, // 15
+		{"/datasetname/@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullIPFSRef, ""},
+		{"/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", idFullRef, ""},
+
+		{"@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", pathOnlyRef, ""},
+		{"@/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y", ipfsOnlyRef, ""},
+		{"@/map/QmcQsi93yUryyWvw6mPyDNoKRb7FcBx8QGBAeJ25kXQjnC", mapRef, ""},
+
+		{"peername/datasetname/@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullRef, ""},
+		{"peername/datasetname/@/ipfs/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullIPFSRef, ""},
+
+		// TODO - restore. These have been removed b/c I didn't have time to make dem work properly - @b5
+		// {"peername/datasetname@/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullIPFSRef, ""},
+		// {"peername/datasetname@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", fullIPFSRef, ""},
+		// {"@/network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", pathOnlyRef, ""},
+		// {"@network/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", pathOnlyRef, ""},
+		// {"@/QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/junk/junk/...", ipfsOnlyRef, ""},
+		// {"@QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D96w1L5qAhUM5Y/junk/junk/...", ipfsOnlyRef, ""},
+
+		// {"peername/datasetname@network/bad_hash", Ref{}, "invalid ProfileID: 'network'"},
+		// {"peername/datasetname@bad_hash/junk/junk..", Ref{}, "invalid ProfileID: 'bad_hash'"},
+		// {"peername/datasetname@bad_hash", Ref{}, "invalid ProfileID: 'bad_hash'"},
+
+		// {"@///*(*)/", Ref{}, "malformed Ref string: @///*(*)/"},
+		// {"///*(*)/", Ref{}, "malformed Ref string: ///*(*)/"},
+		// {"@", Ref{}, ""},
+		// {"///@////", Ref{}, ""},
+	}
+
+	for i, c := range cases {
+		got, err := ParseRef(c.input)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if err := CompareRef(got, c.expect); err != nil {
+			t.Errorf("case %d: %s", i, err.Error())
+		}
+	}
+}
+
+func TestMatch(t *testing.T) {
+	cases := []struct {
+		a, b  string
+		match bool
+	}{
+		{"a/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "a/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", true},
+		{"a/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "a/b@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", true},
+		{"QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/b@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", true},
+
+		{"a/different_name@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", "a/b@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", true},
+		{"different_peername/b@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", "a/b@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", true},
+		{"different_peername/b@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y/b@/b/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", true},
+	}
+
+	for i, c := range cases {
+		a, err := ParseRef(c.a)
+		if err != nil {
+			t.Errorf("case %d error parsing dataset ref a: %s", i, err.Error())
+			continue
+		}
+		b, err := ParseRef(c.b)
+		if err != nil {
+			t.Errorf("case %d error parsing dataset ref b: %s", i, err.Error())
+			continue
+		}
+
+		gotA := a.Match(b)
+		if gotA != c.match {
+			t.Errorf("case %d a.Match", i)
+			continue
+		}
+
+		gotB := b.Match(a)
+		if gotB != c.match {
+			t.Errorf("case %d b.Match", i)
+			continue
+		}
+	}
+}
+
+func TestEqual(t *testing.T) {
+	cases := []struct {
+		a, b  string
+		equal bool
+	}{
+		{"a/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "a/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", true},
+		{"a/b@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "a/b@/ipfs/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", false},
+
+		{"QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1/b@/b/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", true},
+		{"QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1/b@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1/b@/ipfs/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", false},
+
+		{"a/different_name@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "a/b@/ipfs/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", false},
+		{"different_peername/b@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "a/b@/ipfs/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", false},
+
+		{"QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL/different_name@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL/b@/ipfs/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", false},
+		{"QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL/b@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "a/b@/ipfs/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", false},
+		{"QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL/b@/ipfs/QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1", "QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1/b@/ipfs/QmdJgfxj4rocm88PLeEididS7V2cc9nQosA46RpvAnWvDL", false},
+	}
+
+	for i, c := range cases {
+		a, err := ParseRef(c.a)
+		if err != nil {
+			t.Errorf("case %d error parsing dataset ref a: %s", i, err.Error())
+			continue
+		}
+		b, err := ParseRef(c.b)
+		if err != nil {
+			t.Errorf("case %d error parsing dataset ref b: %s", i, err.Error())
+			continue
+		}
+
+		gotA := a.Equal(b)
+		if gotA != c.equal {
+			t.Errorf("case %d a.Equal", i)
+			continue
+		}
+
+		gotB := b.Equal(a)
+		if gotB != c.equal {
+			t.Errorf("case %d b.Equal", i)
+			continue
+		}
+	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	cases := []struct {
+		ref   Ref
+		empty bool
+	}{
+		{Ref{}, true},
+		{Ref{Peername: "a"}, false},
+		{Ref{Name: "a"}, false},
+		{Ref{Path: "a"}, false},
+		{Ref{ProfileID: "a"}, false},
+	}
+
+	for i, c := range cases {
+		got := c.ref.IsEmpty()
+		if got != c.empty {
+			t.Errorf("case %d: %s", i, c.ref)
+			continue
+		}
+	}
+}
+
+func TestCompareRefs(t *testing.T) {
+	cases := []struct {
+		a, b Ref
+		err  string
+	}{
+		{Ref{}, Ref{}, ""},
+		{Ref{Name: "a"}, Ref{}, "Name mismatch. a != "},
+		{Ref{Peername: "a"}, Ref{}, "Peername mismatch. a != "},
+		{Ref{Path: "a"}, Ref{}, "Path mismatch. a != "},
+		{Ref{ProfileID: "QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1"}, Ref{}, "PeerID mismatch. QmRdexT18WuAKVX3vPusqmJTWLeNSeJgjmMbaF5QLGHna1 != "},
+	}
+
+	for i, c := range cases {
+		err := CompareRef(c.a, c.b)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mistmatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
Fixes a stupid bug that come from the fact tat GET requests cannot have a body. 

Our API contained a bug where GET was trying to parse a nonexistent body, and were silently returning 200 status. The fix is to accept dataset ref strings on the /dataset/ endpoint, parse it, and use it for lookup

To do this "properly", we need access to `repo.DatasetRef`'s parse methods, which we can't have directly due to cyclical imports. I've always wanted to have Qri's naming system compose it's own package, but we have a lot of thinking to do around how a change like this would affect our codebase. For now I've stubbed out what a new `ns` package would look like and put it in registry for us to think about, knowing that it'll either move or be removed. At least this way we can ship a fix to registry, and we get the bonus of some code to consider how this might work if used elsewhere.