### PR TITLE
fix(regclient): should use `page` and `pageSize` when requesting from server

### DIFF
--- a/regclient/dataset.go
+++ b/regclient/dataset.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	util "github.com/datatogether/api/apiutil"
 	"github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/registry"
@@ -53,7 +54,9 @@ func (c Client) ListDatasets(limit, offset int) ([]*registry.Dataset, error) {
 		return nil, ErrNoRegistry
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/datasets?limit=%d&offset=%d", c.cfg.Location, limit, offset), nil)
+	page := util.NewPageFromOffsetAndLimit(offset, limit)
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/datasets?page=%d&pageSize=%d", c.cfg.Location, page.Number, page.Size), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
regClient was using `offset` and `limit` to communicate to the regServer, rather than `page` and `pageSize`.

We discussed internally that all potentially user facing APIs should use `page` and `pageSize` rather than limit and offset, so we are switching regClient to use `page` and `pageSize` rather than switching the regServer handlers.