### PR TITLE
chore(apiutil): datatogether/api/apiutil -> qri-io/apiutil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ define GOPACKAGES
 github.com/libp2p/go-libp2p-crypto \
 github.com/jbenet/go-multihash \
 github.com/sirupsen/logrus \
-github.com/datatogether/api/apiutil \
+github.com/qri-io/apiutil \
 github.com/qri-io/dataset
 endef
 

--- a/regclient/dataset.go
+++ b/regclient/dataset.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	util "github.com/datatogether/api/apiutil"
-	"github.com/libp2p/go-libp2p-crypto"
+	crypto "github.com/libp2p/go-libp2p-crypto"
+	util "github.com/qri-io/apiutil"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/registry"
 	"github.com/qri-io/registry/ns"

--- a/regserver/handlers/dataset.go
+++ b/regserver/handlers/dataset.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/apiutil"
 	"github.com/qri-io/registry"
 	"github.com/qri-io/registry/ns"
 )

--- a/regserver/handlers/pins.go
+++ b/regserver/handlers/pins.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/apiutil"
 	"github.com/qri-io/registry/pinset"
 )
 

--- a/regserver/handlers/profile.go
+++ b/regserver/handlers/profile.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/apiutil"
 	"github.com/qri-io/registry"
 )
 

--- a/regserver/handlers/protector.go
+++ b/regserver/handlers/protector.go
@@ -1,52 +1,52 @@
 package handlers
 
 import (
-"errors"
-"net/http"
+	"errors"
+	"net/http"
 
-"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/apiutil"
 )
 
 // MethodProtector is an interface for controling access to http.HandlerFunc's
 // according to request method (GET, PUT, POST, etc.)
 type MethodProtector interface {
-  // ProtectMethods should accept a list of http request methods and return a function that
-  // generates middleware to screen for authorization on those methods.
-  //
-  // For example if "reqHandler" is an http.HandlerFunc, the following would check for 
-  // authentication on all POST requests:
-  //  Protector.ProtectMethods("POST")(reqHandler)
-  ProtectMethods(methods ...string) (func (h http.HandlerFunc) http.HandlerFunc)
+	// ProtectMethods should accept a list of http request methods and return a function that
+	// generates middleware to screen for authorization on those methods.
+	//
+	// For example if "reqHandler" is an http.HandlerFunc, the following would check for
+	// authentication on all POST requests:
+	//  Protector.ProtectMethods("POST")(reqHandler)
+	ProtectMethods(methods ...string) func(h http.HandlerFunc) http.HandlerFunc
 }
 
 // BAProtector implements HTTP Basic Auth checking as a protector
 type BAProtector struct {
-  username, password string
+	username, password string
 }
 
 // NewBAProtector creates a HTTP basic auth protector from a username/password combo
-func NewBAProtector (username, password string) BAProtector {
-  return BAProtector{username, password}
+func NewBAProtector(username, password string) BAProtector {
+	return BAProtector{username, password}
 }
 
 // ProtectMethods implements the MethodProtector interface
-func (ba BAProtector) ProtectMethods(methods ...string) (func (http.HandlerFunc) http.HandlerFunc) {
-  return func(h http.HandlerFunc) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-      for _, m := range methods {
-        if r.Method == m || m == "*" {
-          username, password, set := r.BasicAuth()
-          if !set || username != ba.username || password != ba.password  {
-            log.Infof("invalid key")
-            apiutil.WriteErrResponse(w, http.StatusForbidden, errors.New("invalid key"))
-            return
-          }
-        }
-      }
+func (ba BAProtector) ProtectMethods(methods ...string) func(http.HandlerFunc) http.HandlerFunc {
+	return func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			for _, m := range methods {
+				if r.Method == m || m == "*" {
+					username, password, set := r.BasicAuth()
+					if !set || username != ba.username || password != ba.password {
+						log.Infof("invalid key")
+						apiutil.WriteErrResponse(w, http.StatusForbidden, errors.New("invalid key"))
+						return
+					}
+				}
+			}
 
-      h.ServeHTTP(w, r)
-    }
-  }
+			h.ServeHTTP(w, r)
+		}
+	}
 }
 
 // NoopProtector implements the MethodProtector without doing any checks
@@ -54,14 +54,14 @@ type NoopProtector uint8
 
 // NewNoopProtector creates a NoopProtector
 func NewNoopProtector() NoopProtector {
-  return NoopProtector(0)
+	return NoopProtector(0)
 }
 
 // ProtectMethods implements the MethodProtector interface
-func (NoopProtector) ProtectMethods(methods ...string) (func (http.HandlerFunc) http.HandlerFunc) {
-  return func(h http.HandlerFunc) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-      h.ServeHTTP(w, r)
-    }
-  }
+func (NoopProtector) ProtectMethods(methods ...string) func(http.HandlerFunc) http.HandlerFunc {
+	return func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
 }

--- a/regserver/handlers/reputation.go
+++ b/regserver/handlers/reputation.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/apiutil"
 	"github.com/qri-io/registry"
 )
 

--- a/regserver/handlers/search.go
+++ b/regserver/handlers/search.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/datatogether/api/apiutil"
+	"github.com/qri-io/apiutil"
 	"github.com/qri-io/registry"
 )
 


### PR DESCRIPTION
related to qri-io/qri#784.

During our gomod conversion I keep seeing this odd `github.com/jbenet/go-multihash` import. I suspect our old datatogether dep might be hurting this situation, and since that repo is going to be deprecated, might as well switch over now.